### PR TITLE
[feat]: 상품 생성 시 ai 예측가 생성 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
           
           echo "SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}" >> .env
           echo "SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}" >> .env
+          
+          echo "GPT_API_KEY=${{ secrets.GPT_API_KEY }}" >> .env
 
 
       - name: Build and Push Docker Image to Docker Hub

--- a/src/main/java/com/pieceofcake/product_service/ai/application/AiService.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/application/AiService.java
@@ -1,0 +1,7 @@
+package com.pieceofcake.product_service.ai.application;
+
+import java.util.Map;
+
+public interface AiService {
+    Map<String, Object> modelList();
+}

--- a/src/main/java/com/pieceofcake/product_service/ai/application/AiServiceImpl.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/application/AiServiceImpl.java
@@ -1,0 +1,104 @@
+package com.pieceofcake.product_service.ai.application;
+
+import com.pieceofcake.product_service.ai.dto.in.AiRequestDto;
+import com.pieceofcake.product_service.ai.dto.out.AiResponseDto;
+import com.pieceofcake.product_service.common.config.OpenAiProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+@Slf4j
+@Service
+public class AiServiceImpl implements AiService{
+    private final RestTemplate restTemplate;
+//    private final HttpHeaders httpHeaders;
+    private final OpenAiProperties properties;
+
+//    public AiServiceImpl(RestTemplate restTemplate, HttpHeaders httpHeaders, OpenAiProperties properties) {
+    public AiServiceImpl(RestTemplate restTemplate, OpenAiProperties properties) {
+        this.restTemplate = restTemplate;
+//        this.httpHeaders = httpHeaders;
+        this.properties = properties;
+    }
+
+    @Value("${openai.api.url.model}")
+    private String modelUrl;
+
+    @Value("${openai.api.url.model-list}")
+    private String modelListUrl;
+
+    @Value("${openai.api.url.prompt}")
+    private String promptUrl;
+    /**
+     * 사용 가능한 모델 리스트를 조회하는 비즈니스 로직
+     *
+     * @return List<Map < String, Object>>
+     */
+    @Override
+    public Map<String, Object> modelList() {
+//        HttpEntity<Void> entity = new HttpEntity<>(httpHeaders);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(properties.getKey());
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                modelListUrl,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        return response.getBody();
+    }
+
+    /**
+     * 실제 응답을 받아오는 api
+     */
+    public AiResponseDto getAnswer(AiRequestDto aiRequestDto) {
+
+        // 1. System 역할: 응답 형식 및 역할 정의
+        Map<String, Object> systemMessage = new HashMap<>();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", "당신은 희귀 및 명품 물품의 가격 책정 전문가입니다. 이미지와 설명을 바탕으로 이 물품의 한국 원화 예상 가격을 숫자로만 추정해주세요. 이후 그 예상가를 선정한 이유를 짧게 한 문장으로 설명하세요. 해당 신상품의 가격, 비슷한 대조군 등을 예시에 포함하면 좋습니다. 예: \"32,000. 이 물품은 한정판으로, 현재 시장에서 비슷한 제품의 가격이 30,000원에서 35,000원 사이입니다. 따라서 이 물품의 예상가는 32,000원입니다.\"");
+
+        // 2. User 역할: 텍스트 설명과 이미지 함께 제공
+        Map<String, Object> userMessage = Map.of(
+                "role", "user",
+                "content", List.of(
+                        Map.of("type", "text", "text", aiRequestDto.getDescription()),
+                        Map.of("type", "image_url", "image_url", Map.of("url", aiRequestDto.getImageUrl()))
+                )
+        );
+        // 3. 전체 요청 구성
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", properties.getModel()); // "gpt-4o" 또는 "gpt-4-vision-preview"
+        requestBody.put("temperature", properties.getTemperature());
+        requestBody.put("messages", List.of(systemMessage, userMessage));
+        requestBody.put("max_tokens", properties.getMaxTokens());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(properties.getKey());
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                promptUrl,
+                HttpMethod.POST,
+                entity,
+                Map.class
+        );
+
+        List<Map<String, Object>> choices = (List<Map<String, Object>>) response.getBody().get("choices");
+        Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+        String content = (String) message.get("content");
+
+        return new AiResponseDto(properties.getModel(), content.trim());
+    }
+
+
+}

--- a/src/main/java/com/pieceofcake/product_service/ai/dto/in/AiRequestDto.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/dto/in/AiRequestDto.java
@@ -1,0 +1,33 @@
+package com.pieceofcake.product_service.ai.dto.in;
+
+import com.pieceofcake.product_service.ai.vo.in.AiRequestVo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AiRequestDto {
+    private String description;  // 물품 설명
+    private String imageUrl;
+
+    @Builder
+    public AiRequestDto(String description, String imageUrl) {
+        this.description = description;
+        this.imageUrl = imageUrl;
+    }
+
+    public static AiRequestDto from(AiRequestVo aiRequestVo) {
+        return AiRequestDto.builder()
+                .description(aiRequestVo.getDescription())
+                .imageUrl(aiRequestVo.getImageUrl())
+                .build();
+    }
+
+    public static AiRequestDto of(String description, String fileName) {
+        return AiRequestDto.builder()
+                .description(description)
+                .imageUrl(fileName)
+                .build();
+    }
+}

--- a/src/main/java/com/pieceofcake/product_service/ai/dto/out/AiResponseDto.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/dto/out/AiResponseDto.java
@@ -1,0 +1,33 @@
+package com.pieceofcake.product_service.ai.dto.out;
+
+import com.pieceofcake.product_service.ai.vo.out.AiResponseVo;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AiResponseDto {
+    private String model;
+    private String result;
+
+    @Builder
+    public AiResponseDto(String model, String result) {
+        this.model = model;
+        this.result = result;
+    }
+
+    public static AiResponseDto of(String model, String result) {
+        return AiResponseDto.builder()
+                .model(model)
+                .result(result)
+                .build();
+    }
+
+    public AiResponseVo toVo() {
+        return AiResponseVo.builder()
+                .model(model)
+                .result(result)
+                .build();
+    }
+}

--- a/src/main/java/com/pieceofcake/product_service/ai/presentation/AiController.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/presentation/AiController.java
@@ -1,0 +1,32 @@
+package com.pieceofcake.product_service.ai.presentation;
+
+import com.pieceofcake.product_service.ai.application.AiServiceImpl;
+import com.pieceofcake.product_service.ai.dto.in.AiRequestDto;
+import com.pieceofcake.product_service.ai.dto.out.AiResponseDto;
+import com.pieceofcake.product_service.ai.vo.in.AiRequestVo;
+import com.pieceofcake.product_service.ai.vo.out.AiResponseVo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AiController {
+
+    public final AiServiceImpl aiService;
+
+    @PostMapping("/price")
+    public ResponseEntity<AiResponseVo> selectPrompt(
+            @RequestBody AiRequestVo aiRequestVo
+    ) {
+        AiResponseDto aiResponseDto = aiService.getAnswer(AiRequestDto.from(aiRequestVo));
+        AiResponseVo aiResponseVo = aiResponseDto.toVo();
+        return new ResponseEntity<>(aiResponseVo, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/pieceofcake/product_service/ai/vo/in/AiRequestVo.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/vo/in/AiRequestVo.java
@@ -1,0 +1,11 @@
+package com.pieceofcake.product_service.ai.vo.in;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AiRequestVo {
+    private String description;
+    private String imageUrl;
+}

--- a/src/main/java/com/pieceofcake/product_service/ai/vo/out/AiResponseVo.java
+++ b/src/main/java/com/pieceofcake/product_service/ai/vo/out/AiResponseVo.java
@@ -1,0 +1,16 @@
+package com.pieceofcake.product_service.ai.vo.out;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AiResponseVo {
+    private String model;
+    private String result;
+
+    @Builder
+    public AiResponseVo(String model, String result) {
+        this.model = model;
+        this.result = result;
+    }
+}

--- a/src/main/java/com/pieceofcake/product_service/common/config/AppConfig.java
+++ b/src/main/java/com/pieceofcake/product_service/common/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.pieceofcake.product_service.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/pieceofcake/product_service/common/config/OpenAiProperties.java
+++ b/src/main/java/com/pieceofcake/product_service/common/config/OpenAiProperties.java
@@ -1,0 +1,23 @@
+package com.pieceofcake.product_service.common.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "openai.api")
+public class OpenAiProperties {
+    private String key;
+    private String model;
+    private double temperature;
+    private int maxTokens;
+    private Url url;
+
+    @Data
+    public static class Url {
+        private String model;
+        private String modelList;
+        private String prompt;
+    }
+}

--- a/src/main/java/com/pieceofcake/product_service/product/dto/in/CreateProductRequestDto.java
+++ b/src/main/java/com/pieceofcake/product_service/product/dto/in/CreateProductRequestDto.java
@@ -1,7 +1,6 @@
 package com.pieceofcake.product_service.product.dto.in;
 
 import com.pieceofcake.product_service.category.dto.in.CategoryDto;
-import com.pieceofcake.product_service.category.vo.in.CategoryVo;
 import com.pieceofcake.product_service.product.entity.Product;
 import com.pieceofcake.product_service.product.entity.ProductStatus;
 import com.pieceofcake.product_service.product.vo.in.CreateProductRequestVo;
@@ -13,8 +12,6 @@ import java.util.List;
 @Getter
 public class CreateProductRequestDto {
     private String productName;
-    private Long aiEstimatedPrice;
-    private String aiEstimatedDescription;
     private Long purchasePrice;
     private ProductStatus status;
     private String storageLocation;
@@ -24,11 +21,10 @@ public class CreateProductRequestDto {
     private CategoryDto subCategory;
 
     @Builder
-    public CreateProductRequestDto(String productName, Long aiEstimatedPrice, String aiEstimatedDescription,
-                                   Long purchasePrice, ProductStatus status, String storageLocation, String description, List<ProductImageRequestDto> productImageRequestDtoList, CategoryDto mainCategory, CategoryDto subCategory) {
+    public CreateProductRequestDto(String productName, Long purchasePrice, ProductStatus status,
+                                   String storageLocation, String description, List<ProductImageRequestDto> productImageRequestDtoList,
+                                   CategoryDto mainCategory, CategoryDto subCategory) {
         this.productName = productName;
-        this.aiEstimatedPrice = aiEstimatedPrice;
-        this.aiEstimatedDescription = aiEstimatedDescription;
         this.purchasePrice = purchasePrice;
         this.status = status;
         this.storageLocation = storageLocation;
@@ -39,11 +35,9 @@ public class CreateProductRequestDto {
     }
 
 
-    public static CreateProductRequestDto from(CreateProductRequestVo vo){
+    public static CreateProductRequestDto from(CreateProductRequestVo vo) {
         return CreateProductRequestDto.builder()
                 .productName(vo.getProductName())
-                .aiEstimatedPrice(vo.getAiEstimatedPrice())
-                .aiEstimatedDescription(vo.getAiEstimatedDescription())
                 .purchasePrice(vo.getPurchasePrice())
                 .status(vo.getStatus())
                 .storageLocation(vo.getStorageLocation())
@@ -55,8 +49,7 @@ public class CreateProductRequestDto {
                 .build();
     }
 
-
-    public Product toEntity(String productUuid){
+    public Product toEntity(String productUuid, Long aiEstimatedPrice, String aiEstimatedDescription) {
         return Product.builder()
                 .productUuid(productUuid)
                 .productName(productName)

--- a/src/main/java/com/pieceofcake/product_service/product/entity/Product.java
+++ b/src/main/java/com/pieceofcake/product_service/product/entity/Product.java
@@ -2,13 +2,11 @@ package com.pieceofcake.product_service.product.entity;
 
 import com.pieceofcake.product_service.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @Entity
 public class Product extends BaseEntity {
     @Id
@@ -25,7 +23,8 @@ public class Product extends BaseEntity {
     @Column(name = "ai_estimated_price", nullable = false)
     private Long aiEstimatedPrice;
 
-    @Column(name = "ai_estimated_description")
+    @Lob
+    @Column(name = "ai_estimated_description", columnDefinition = "LONGTEXT")
     private String aiEstimatedDescription;
 
     @Column(name = "purchase_price", nullable = false)
@@ -39,24 +38,10 @@ public class Product extends BaseEntity {
     private String storageLocation;
 
     @Lob
-    @Column(name = "description", nullable = false)
+    @Column(name = "description", nullable = false, columnDefinition = "LONGTEXT")
     private String description;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
-
-    @Builder
-    public Product(Long id, String productUuid, String productName, Long aiEstimatedPrice, String aiEstimatedDescription,
-                   Long purchasePrice, ProductStatus productStatus, String storageLocation, String description, Boolean isDeleted) {
-        this.id = id;
-        this.productUuid = productUuid;
-        this.productName = productName;
-        this.aiEstimatedPrice = aiEstimatedPrice;
-        this.aiEstimatedDescription = aiEstimatedDescription;
-        this.purchasePrice = purchasePrice;
-        this.productStatus = productStatus;
-        this.storageLocation = storageLocation;
-        this.description = description;
-        this.isDeleted = isDeleted;
-    }
 }

--- a/src/main/java/com/pieceofcake/product_service/product/vo/in/CreateProductRequestVo.java
+++ b/src/main/java/com/pieceofcake/product_service/product/vo/in/CreateProductRequestVo.java
@@ -10,8 +10,6 @@ import java.util.List;
 @Getter
 public class CreateProductRequestVo {
     private String productName;
-    private Long aiEstimatedPrice;
-    private String aiEstimatedDescription;
     private Long purchasePrice;
     private ProductStatus status;
     private String storageLocation;
@@ -21,11 +19,10 @@ public class CreateProductRequestVo {
     private CategoryVo subCategory;
 
     @Builder
-    public CreateProductRequestVo(String productName, Long aiEstimatedPrice, String aiEstimatedDescription, Long purchasePrice,
-                                  ProductStatus status, String storageLocation, String description, List<ProductImageRequestVo> productImageRequestVoList, CategoryVo mainCategory, CategoryVo subCategory) {
+    public CreateProductRequestVo(String productName, Long purchasePrice, ProductStatus status, String storageLocation,
+                                  String description, List<ProductImageRequestVo> productImageRequestVoList, CategoryVo mainCategory,
+                                  CategoryVo subCategory) {
         this.productName = productName;
-        this.aiEstimatedPrice = aiEstimatedPrice;
-        this.aiEstimatedDescription = aiEstimatedDescription;
         this.purchasePrice = purchasePrice;
         this.status = status;
         this.storageLocation = storageLocation;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,3 +15,15 @@ spring:
       batch-size: 16384
       linger-ms: 1
       buffer-memory: 33554432
+
+openai:
+  api:
+    model: gpt-4o
+    key: ${GPT_API_KEY}
+    temperature: 0.0
+    maxTokens: 500
+
+    url:
+      model: https://api.openai.com/v1/models
+      model-list: https://api.openai.com/v1/models
+      prompt: https://api.openai.com/v1/chat/completions


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1

## 📝작업 내용

> - gpt api를 사용하여 상품 이미지, 설명을 사용하여 예측가 생성
> - 생성된 예측가를 파싱하여 상품 db 저장 및 event message에 추가
> - gpt api key값 등록